### PR TITLE
Add tabulate to the install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,8 @@ setup(
         'wrapt>=1.10.11',
         'PyQt5>=5.10.1',
         'scipy>=1.1.0',
-        'numpy>=1.14.3'
+        'numpy>=1.14.3',
+        'tabulate>=0.8.3'
     ],
     python_requires='>=3'
 )


### PR DESCRIPTION
The tabulate package is used in tools/snapshot.py but isn't
specified as a dependency.

