### PR TITLE
Bump python version for dict union syntax

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,5 @@ setup(
         'tqdm>=4.41.1',
         'requests>=2.22.0'
     ],
-    python_requires='>=3.6'
+    python_requires='>=3.9'
 )


### PR DESCRIPTION
Hi Seb,
You've used the dictionary union syntax with the '|' operator in doNd.py. This was added in 3.9, so just bumping the version to avoid confusion.
