### PR TITLE
drivers/fridge.py Add a fake IDN string

### DIFF
--- a/qcodes_measurements/drivers/fridge.py
+++ b/qcodes_measurements/drivers/fridge.py
@@ -1,5 +1,5 @@
 from functools import partial
-
+from typing import Optional, Dict
 import requests
 from qcodes import Instrument
 
@@ -54,3 +54,12 @@ class FridgeTemps(Instrument):
         Override for pylint
         """
         raise NotImplementedError("Can't communicate directly with a fridge.")
+
+    def get_idn(self) -> Dict[str, Optional[str]]:
+        """
+        Returns details of the instrument and driver.
+        """
+        return {"vendor": "QNL",
+                "model": "Fridge URL Driver",
+                "serial": "0001",
+                "firmware": "0.1"}


### PR DESCRIPTION
The instrument base class tries to query *IDN?, so we can provide a fake one.

Feel free to change the version numbers @spauka - I just needed to provide one for QCODES to move forward
